### PR TITLE
+agrego correccion de codificacion por bom

### DIFF
--- a/src/sileg/bp/web/students/forms.py
+++ b/src/sileg/bp/web/students/forms.py
@@ -123,7 +123,7 @@ class StudentCSVCreateForm(FlaskForm):
             checkStudentNumber = re.compile('\d+\/\d+')
             checkIdentityNumber = re.compile('^[0-9]+$')
             response = []
-            csv_file = io.TextIOWrapper(self.newFile.data, encoding='utf-8')
+            csv_file = io.TextIOWrapper(self.newFile.data, encoding='utf-8-sig')
             csv_reader = csv.DictReader(csv_file, delimiter=',')
             for row in csv_reader:
                 with open_users_session() as session:


### PR DESCRIPTION
Agrego corrección de BOM, al parecer el archivo CSV a cargar fue creado o editado con notepad o utilidad similar y al estar en unicode genero la marca de BOM, la cual es incompatible con UTF-8, se cambio la codificación a utf-8-sig, la cual ignora los primeros 3 bytes del archivo.